### PR TITLE
Add a fix to rename parameters of abstract methods to SRG

### DIFF
--- a/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 public class AbstractParameterRename {
 
     // Definitions of methods must contain both a non-empty parameter list and end with a semicolon.
-    public static final Pattern METHOD_DECLARATION = Pattern.compile("(.*)\\(.+\\);");
+    public static final Pattern METHOD_DECLARATION = Pattern.compile("(.*)\\(.+var\\d+.+\\);");
 
     // Bear with me here.
     // We need the number from the SRG function, so we read the whole method declaration.

--- a/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
@@ -1,0 +1,72 @@
+package net.minecraftforge.mcpcleanup;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AbstractParameterRename {
+
+    // Definitions of abstract methods must contain both the keyword abstract and end with a semicolon.
+    public static final Pattern ABSTRACT_METHOD = Pattern.compile("(?:abstract) (.*)\\(.+\\);");
+
+    // Bear with me here.
+    // We need the number from the SRG function, so we read the whole method declaration.
+    // The argument list is any number of:
+    // ( [annotation] <type> <identifier> <separator> )
+    // succeeded by an optional throws declaration, and a list of exceptions.
+    public static final Pattern FUNCTION_DEFINITION = Pattern.compile(
+            " (?<method>func_(?<number>\\d+)_[a-zA-Z_]+)\\((?<arguments>(?:(?<annotation>(?:\\@(?:[a-zA-Z_$][\\w_$\\.]*)(?:\\((?:.+)*\\))? ?))?(?<type>(?:[^ ,])+(?:<.*>)?(?: \\.\\.\\.)?) var(?<id>\\d+)(?<end>,? )?)+)\\)(?: throws (?:[\\w$.]+,? ?)+)?;$"
+    );
+
+    // Once we have parsed a method declaration, we need to be able to extract the parameter information:
+    // As before:
+    // The argument list is any number of:
+    // ( [annotation] <type> <identifier> <separator> )
+    // This time, we only want the IDs from the definition.
+    public static final Pattern PARAMETER_LIST = Pattern.compile(
+            "(?:(?<annotation>(?:\\@(?:[a-zA-Z_$][\\w_$\\.]*)(?:\\((?:.+)*\\))? ?))?(?<type>(?:[^ ,])+(?:<.*>)?(?: \\.\\.\\.)?) var(?<id>\\d+)(?<end>,? )?)"
+    );
+
+    // A drop-in replacement for Python's Regex.sub, including the lambda replacement.
+    public static String sub(String original, Pattern tokenPattern, Function<Matcher, String> converter) {
+        int lastIndex = 0;
+        StringBuilder output = new StringBuilder();
+        Matcher matcher = tokenPattern.matcher(original);
+        while (matcher.find()) {
+            output.append(original, lastIndex, matcher.start())
+                    .append(converter.apply(matcher));
+
+            lastIndex = matcher.end();
+        }
+        if (lastIndex < original.length()) {
+            output.append(original, lastIndex, original.length());
+        }
+        return output.toString();
+    }
+
+    public static String fixAbstractParameters(String file) {
+        // Filter for files that even contain an abstract method.
+        //         if (line.endswith(";")):
+        file = sub(file, ABSTRACT_METHOD, outerMatch -> {
+            String method = outerMatch.group(0);
+            // Parse the method definition
+            //             line = _REGEXP['abstract'].sub(abstract_match, line)
+            method = sub(method, FUNCTION_DEFINITION, methodMatch -> {
+                // Fetch arguments
+                //             args = match.group('arguments')
+                String arguments = methodMatch.group("arguments");
+                // Rename the arguments accordingly.
+                //             args = _REGEXP['params_var'].sub(lambda m: '%s p_%s_%s_%s' % (m.group('type'), match.group('number'), m.group('id'), m.group('end') if not m.group('end') is None else ''), args)
+                arguments = sub(arguments, PARAMETER_LIST, param -> String.format("%s p_%s_%s_%s", param.group("type"), methodMatch.group("number"), param.group("id"), param.group("end") != null ? param.group("end") : ""));
+
+                // return match.group(0).replace(match.group('arguments'), args)
+                return methodMatch.group(0).replace(methodMatch.group("arguments"), arguments);
+            });
+
+            return method;
+        });
+
+        return file;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.mcpcleanup;
 
 import java.util.function.Function;

--- a/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 public class AbstractParameterRename {
 
     // Definitions of abstract methods must contain both the keyword abstract and end with a semicolon.
-    public static final Pattern ABSTRACT_METHOD = Pattern.compile("(?:abstract) (.*)\\(.+\\);");
+    public static final Pattern ABSTRACT_METHOD = Pattern.compile("(.*)\\(.+\\);");
 
     // Bear with me here.
     // We need the number from the SRG function, so we read the whole method declaration.

--- a/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/AbstractParameterRename.java
@@ -6,8 +6,8 @@ import java.util.regex.Pattern;
 
 public class AbstractParameterRename {
 
-    // Definitions of abstract methods must contain both the keyword abstract and end with a semicolon.
-    public static final Pattern ABSTRACT_METHOD = Pattern.compile("(.*)\\(.+\\);");
+    // Definitions of methods must contain both a non-empty parameter list and end with a semicolon.
+    public static final Pattern METHOD_DECLARATION = Pattern.compile("(.*)\\(.+\\);");
 
     // Bear with me here.
     // We need the number from the SRG function, so we read the whole method declaration.
@@ -47,7 +47,7 @@ public class AbstractParameterRename {
     public static String fixAbstractParameters(String file) {
         // Filter for files that even contain an abstract method.
         //         if (line.endswith(";")):
-        file = sub(file, ABSTRACT_METHOD, outerMatch -> {
+        file = sub(file, METHOD_DECLARATION, outerMatch -> {
             String method = outerMatch.group(0);
             // Parse the method definition
             //             line = _REGEXP['abstract'].sub(abstract_match, line)

--- a/src/main/java/net/minecraftforge/mcpcleanup/ConsoleTool.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/ConsoleTool.java
@@ -17,6 +17,7 @@ public class ConsoleTool {
         OptionSpec<File> inputO = parser.accepts("input").withRequiredArg().ofType(File.class).required();
         OptionSpec<File> outputO = parser.accepts("output").withRequiredArg().ofType(File.class).required();
         OptionSpec<Void> filterFMLO = parser.accepts("filter-fml", "Filter out net.minecraftforge and cpw.mods.fml package, in the cases where we inject the Side annotations.");
+        OptionSpec<Void> fixGeneric = parser.accepts("fix-generic-params", "Fix parameters of generic and interface methods, who get parameters named var{x} rather than SRG IDs.");
 
         try {
             OptionSet options = parser.parse(args);
@@ -24,15 +25,19 @@ public class ConsoleTool {
             File input = options.valueOf(inputO);
             File output  = options.valueOf(outputO);
             boolean filterFML = options.has(filterFMLO);
+            boolean fixParams = options.has(fixGeneric);
 
             log("MCPCleanup: ");
             log("  Input:     " + input);
             log("  Output:    " + output);
             log("  FilterFML: " + filterFML);
+            log("  FixGenericParams: " + fixParams);
 
             MCPCleanup cleanup = MCPCleanup.create(input, output);
             if (filterFML)
                 cleanup.filterFML();
+            if (fixParams)
+                cleanup.fixParams();
             cleanup.process();
         } catch (OptionException e) {
             parser.printHelpOn(System.out);

--- a/src/main/java/net/minecraftforge/mcpcleanup/MCPCleanup.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/MCPCleanup.java
@@ -34,6 +34,7 @@ public class MCPCleanup {
     private final ASFormatter formatter = new ASFormatter();
     private final GLConstantFixer oglFixer;
     private boolean filterFML = false;
+    private boolean fixParams = false;
 
     public static MCPCleanup create(File input, File output) {
         return new MCPCleanup(input, output);
@@ -71,6 +72,11 @@ public class MCPCleanup {
 
     public MCPCleanup filterFML() {
         this.filterFML = true;
+        return this;
+    }
+
+    public MCPCleanup fixParams() {
+        this.fixParams = true;
         return this;
     }
 
@@ -123,8 +129,10 @@ public class MCPCleanup {
         log("  various other cleanup");
         file = BasicCleanups.cleanup(file);
 
-        log(" fixing abstract parameter names");
-        file = AbstractParameterRename.fixAbstractParameters(file);
+        if (fixParams) {
+            log(" fixing abstract parameter names");
+            file = AbstractParameterRename.fixAbstractParameters(file);
+        }
 
         log("  fixing OGL constants");
         file = oglFixer.fixOGL(file);

--- a/src/main/java/net/minecraftforge/mcpcleanup/MCPCleanup.java
+++ b/src/main/java/net/minecraftforge/mcpcleanup/MCPCleanup.java
@@ -78,7 +78,7 @@ public class MCPCleanup {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT")); //Fix Java stupidity that causes timestamps in zips to depend on user's timezone!
         if (output.exists() && !output.delete()) throw new IOException("Could not delete file: " + output);
         File parent = output.getParentFile();
-        if (!parent.exists() && !parent.mkdirs()) throw new IOException("Could not make prent folders: " + parent);
+        if (!parent.exists() && !parent.mkdirs()) throw new IOException("Could not make parent folders: " + parent);
 
         dirs.clear();
 
@@ -122,6 +122,9 @@ public class MCPCleanup {
 
         log("  various other cleanup");
         file = BasicCleanups.cleanup(file);
+
+        log(" fixing abstract parameter names");
+        file = AbstractParameterRename.fixAbstractParameters(file);
 
         log("  fixing OGL constants");
         file = oglFixer.fixOGL(file);


### PR DESCRIPTION
## Why?

Abstract methods have no LVT, and thus parameter metadata (they are synthetic, generated in code by the decompiler) so MCInjector, the tool that usually generates SRG parameter names, is unable to even know that they exist and should be renamed.

With MCInjector pinned to version 3.4.5 (and thus, without the abstract parameter rename feature implemented 3 years later), the only clean place to rename these parameters post-decompile is with the postprocessor; namely, MCPCleanup.

## What?

The abstract parameter rename process can be summed up as:
 * Find files that contain a definition for an abstract method with at least one parameter
 * Process the method definition by:
     * Processing the argument definitions by:
         * Renaming all arguments to p_{method id}_{parameter index}_
     * Replace the argument definition with the renamed version
 * Replace the method definition with the renamed version
 
 This is implemented as an ungodly chain of regular expressions because that was the fastest and easiest option.